### PR TITLE
Cleanup all memory in the Worker

### DIFF
--- a/src/window/lifecycle.js
+++ b/src/window/lifecycle.js
@@ -39,9 +39,11 @@ export function define(fritz, msg) {
 export function render(fritz, msg){
   let id = msg.id;
   let instance = getInstance(fritz, msg.id);
-  instance.doRenderCallback(msg.tree);
-  if(msg.events) {
-    instance.observedEventsCallback(msg.events);
+  if(instance !== undefined) {
+    instance.doRenderCallback(msg.tree);
+    if(msg.events) {
+      instance.observedEventsCallback(msg.events);
+    }
   }
 };
 

--- a/src/worker/component.js
+++ b/src/worker/component.js
@@ -1,4 +1,5 @@
 import { RENDER, TRIGGER } from '../message-types.js';
+import { renderInstance } from './instance.js';
 
 class Component {
   dispatch(ev) {
@@ -15,7 +16,7 @@ class Component {
     postMessage({
       type: RENDER,
       id: id,
-      tree: this.render()
+      tree: renderInstance(this)
     });
   }
 

--- a/src/worker/handle.js
+++ b/src/worker/handle.js
@@ -46,6 +46,12 @@ Handle = class {
     this.id = id;
     this.fn = fn;
   }
+
+  del() {
+    let store = Handle.store;
+    store.handleMap.delete(this.fn);
+    store.idMap.delete(this.id);
+  }
 }
 
 export default Handle;

--- a/src/worker/instance.js
+++ b/src/worker/instance.js
@@ -1,0 +1,8 @@
+export let currentInstance = null;
+
+export function renderInstance(instance) {
+  currentInstance = instance;
+  let tree = instance.render();
+  currentInstance = null;
+  return tree;
+};

--- a/src/worker/signal.js
+++ b/src/worker/signal.js
@@ -1,3 +1,4 @@
+import { currentInstance } from './instance.js';
 import Handle from './handle.js';
 
 const eventAttrExp = /^on[A-Z]/;
@@ -5,8 +6,9 @@ const eventAttrExp = /^on[A-Z]/;
 function signal(tagName, attrName, attrValue, attrs) {
   if(eventAttrExp.test(attrName)) {
     let eventName = attrName.toLowerCase();
-    let id = Handle.from(attrValue).id;
-    return [1, eventName, id];
+    let handle = Handle.from(attrValue);
+    currentInstance._fritzHandles[handle.id] = handle;
+    return [1, eventName, handle.id];
   }
 }
 

--- a/test/basics/app.js
+++ b/test/basics/app.js
@@ -1,10 +1,13 @@
 importScripts('../../worker.umd.js');
+importScripts('../worker-debug.js');
 
 const { h, Component } = fritz;
 
 class AnotherEl extends Component {
+  doStuff(){}
+
   render() {
-    return h('div', ['Another el']);
+    return h('div', { onClick: this.doStuff }, ['Another el']);
   }
 }
 

--- a/test/cleanup.html
+++ b/test/cleanup.html
@@ -24,13 +24,40 @@
 
           describe('Removing an element', function(){
             before(function(done){
-              let basicApp = doc.querySelector('basic-app');
-              basicApp.parentNode.removeChild(basicApp);
-              setTimeout(done, 100);
+              testHelpers.runInWorker(function(){
+                let id = Object.keys(fritz._instances)[1];
+                self.anotherInstance = fritz._instances[id];
+              })
+              .then(function(){
+                let basicApp = doc.querySelector('basic-app');
+                basicApp.parentNode.removeChild(basicApp);
+                setTimeout(done, 100);
+              });
             });
 
             it('removes it from the instance store', function(){
               assert.equal(testHelpers.instanceCount(win), 0, 'There are no instances');
+            });
+
+            it('removes worker instance', function(done){
+              testHelpers.runInWorker(function(){
+                return Object.keys(fritz._instances).length;
+              })
+              .then(function(count){
+                assert.equal(count, 0);
+              })
+              .then(done);
+            });
+
+            it('removes all handles', function(done){
+              testHelpers.runInWorker(function(){
+                let inst = self.anotherInstance;
+                return Object.keys(inst._fritzHandles).length;
+              })
+              .then(function(count){
+                assert.equal(count, 0);
+              })
+              .then(done, done);
             });
           });
         });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,37 @@
 makeTestHelpers = function(win){
+  let uniq = 1;
+
   return {
-      instanceCount() {
+    instanceCount() {
       return Object.keys(win.fritz._instances).length;
+    },
+    runInWorker(fn) {
+      let src = fn.toString();
+      let worker = win.fritz._workers[0];
+      let id = ++uniq;
+      worker.postMessage({
+        type: 'TEST_DEBUG',
+        id: id,
+        src: src
+      });
+
+      return new Promise(function(resolve, reject){
+        worker.addEventListener('message', function onmsg(ev){
+          let msg = ev.data;
+          switch(msg.type) {
+            case 'TEST_DEBUG':
+              if(msg.id === id) {
+                worker.removeEventListener('message', onmsg);
+                if(!msg.error) {
+                  resolve(msg.result);
+                } else {
+                  reject(new Error(msg.error));
+                }
+              }
+              break;
+          }
+        });
+      });
     }
   };
 };

--- a/test/worker-debug.js
+++ b/test/worker-debug.js
@@ -1,0 +1,29 @@
+
+self.addEventListener('message', function(ev){
+  let msg = ev.data;
+  switch(msg.type) {
+    case 'TEST_DEBUG':
+      evalTestCode(msg);
+      break;
+  }
+});
+
+function evalTestCode(msg) {
+  let src = 'return ('+ msg.src + ')();';
+  let fn = new Function(src);
+  try {
+    let result = fn();
+    postMessage({
+      type: 'TEST_DEBUG',
+      result: result,
+      id: msg.id
+    });
+  } catch(err) {
+    postMessage({
+      type: 'TEST_DEBUG',
+      id: msg.id,
+      error: err.message,
+      stack: err.stack
+    });
+  }
+}

--- a/window.js
+++ b/window.js
@@ -1685,9 +1685,11 @@ function define(fritz, msg) {
 function render(fritz, msg){
   let id = msg.id;
   let instance = getInstance(fritz, msg.id);
-  instance.doRenderCallback(msg.tree);
-  if(msg.events) {
-    instance.observedEventsCallback(msg.events);
+  if(instance !== undefined) {
+    instance.doRenderCallback(msg.tree);
+    if(msg.events) {
+      instance.observedEventsCallback(msg.events);
+    }
   }
 }
 

--- a/window.umd.js
+++ b/window.umd.js
@@ -1691,9 +1691,11 @@ function define(fritz, msg) {
 function render(fritz, msg){
   let id = msg.id;
   let instance = getInstance(fritz, msg.id);
-  instance.doRenderCallback(msg.tree);
-  if(msg.events) {
-    instance.observedEventsCallback(msg.events);
+  if(instance !== undefined) {
+    instance.doRenderCallback(msg.tree);
+    if(msg.events) {
+      instance.observedEventsCallback(msg.events);
+    }
   }
 }
 

--- a/worker.js
+++ b/worker.js
@@ -5,6 +5,15 @@ const EVENT = 'event';
 const STATE = 'state';
 const DESTROY = 'destroy';
 
+let currentInstance = null;
+
+function renderInstance(instance) {
+  currentInstance = instance;
+  let tree = instance.render();
+  currentInstance = null;
+  return tree;
+}
+
 class Component {
   dispatch(ev) {
     let id = this._fritzId;
@@ -20,7 +29,7 @@ class Component {
     postMessage({
       type: RENDER,
       id: id,
-      tree: this.render()
+      tree: renderInstance(this)
     });
   }
 
@@ -76,6 +85,12 @@ Handle = class {
     this.id = id;
     this.fn = fn;
   }
+
+  del() {
+    let store = Handle.store;
+    store.handleMap.delete(this.fn);
+    store.idMap.delete(this.id);
+  }
 };
 
 var Handle$1 = Handle;
@@ -85,8 +100,9 @@ const eventAttrExp = /^on[A-Z]/;
 function signal(tagName, attrName, attrValue, attrs) {
   if(eventAttrExp.test(attrName)) {
     let eventName = attrName.toLowerCase();
-    let id = Handle$1.from(attrValue).id;
-    return [1, eventName, id];
+    let handle = Handle$1.from(attrValue);
+    currentInstance._fritzHandles[handle.id] = handle;
+    return [1, eventName, handle.id];
   }
 }
 
@@ -201,9 +217,16 @@ function render(fritz, msg) {
   if(!instance) {
     let constructor = fritz._tags[msg.tag];
     instance = new constructor();
-    Object.defineProperty(instance, '_fritzId', {
-      enumerable: false,
-      value: id
+    Object.defineProperties(instance, {
+      _fritzId: {
+        enumerable: false,
+        value: id
+      },
+      _fritzHandles: {
+        enumerable: false,
+        writable: true,
+        value: Object.create(null)
+      }
     });
     setInstance(fritz, id, instance);
     events = constructor.observedEvents;
@@ -211,7 +234,7 @@ function render(fritz, msg) {
 
   Object.assign(instance, props);
 
-  let tree = instance.render();
+  let tree = renderInstance(instance);
   postMessage({
     type: RENDER,
     id: id,
@@ -250,6 +273,11 @@ function trigger(fritz, msg){
 function destroy(fritz, msg){
   let instance = getInstance(fritz, msg.id);
   instance.destroy();
+  Object.keys(instance._fritzHandles).forEach(function(key){
+    let handle = instance._fritzHandles[key];
+    handle.del();
+  });
+  instance._fritzHandles = Object.create(null);
   delInstance(fritz, msg.id);
 }
 


### PR DESCRIPTION
This ensures that all memory created in the worker, such as handles, are also cleaned up when an element is removed.

Also adds a way to test code that is in a worker.