### PR TITLE
Allow custom events

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -9,3 +9,7 @@ export function setInstance(fritz, id, instance){
 export function delInstance(fritz, id){
   delete fritz._instances[id];
 };
+
+export function isFunction(val) {
+  return typeof val === 'function';
+};

--- a/src/window/component.js
+++ b/src/window/component.js
@@ -42,11 +42,31 @@ export const withComponent = (Base = HTMLElement) => class extends withUnique(wi
   }
 
   addEventCallback(handleId) {
+    // TODO optimize this so functions are reused if possible.
     var self = this;
-    return function(ev){
+    var fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
+
+    return fn;
+  }
+
+  addEventProperty(name) {
+    var evName = name.substr(2);
+    var priv = '_' + name;
+    var proto = Object.getPrototypeOf(this);
+    Object.defineProperty(proto, name, {
+      get: function(){ return this[priv]; },
+      set: function(val) {
+        var cur;
+        if(cur = this[priv]) {
+          this.removeEventListener(evName, cur);
+        }
+        this[priv] = val;
+        this.addEventListener(evName, val);
+      }
+    });
   }
 
   handleEvent(ev) {

--- a/src/window/component.js
+++ b/src/window/component.js
@@ -21,6 +21,11 @@ function postEvent(event, inst, handle) {
 }
 
 export const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
+  constructor() {
+    super();
+    this._handlers = Object.create(null);
+  }
+
   rendererCallback (shadowRoot, renderCallback) {
     this._worker.postMessage({
       type: RENDER,
@@ -41,14 +46,20 @@ export const withComponent = (Base = HTMLElement) => class extends withUnique(wi
     });
   }
 
-  addEventCallback(handleId) {
+  addEventCallback(handleId, eventProp) {
+    var key = eventProp + '/' + handleId;
+    var fn;
+    if(fn = this._handlers[key]) {
+      return fn;
+    }
+
     // TODO optimize this so functions are reused if possible.
     var self = this;
-    var fn = function(ev){
+    fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
-
+    this._handlers[key] = fn;
     return fn;
   }
 

--- a/src/window/idom-render.js
+++ b/src/window/idom-render.js
@@ -6,6 +6,9 @@ import {
   text,
   patch
 } from 'incremental-dom';
+import { isFunction } from '../util.js';
+
+var eventAttrExp = /^on[a-z]/;
 
 var attributesSet = attributes[symbols.default];
 attributes[symbols.default] = preferProps;
@@ -13,6 +16,11 @@ attributes[symbols.default] = preferProps;
 function preferProps(element, name, value){
   if(name in element)
     element[name] = value;
+  else if(isFunction(value) && eventAttrExp.test(name) &&
+    isFunction(element.addEventProperty)) {
+    element.addEventProperty(name);
+    element[name] = value;
+  }
   else
     attributesSet(element, name, value);
 }
@@ -25,9 +33,11 @@ function render(bc, component){
       // Open
       case 1:
         if(n[3]) {
+          var k;
           for(var j = 0, jlen = n[3].length; j < jlen; j++) {
-            let handler = component.addEventCallback(n[3][j][2]);
-            n[2].push(n[3][j][1], handler);
+            k = n[3][j];
+            let handler = component.addEventCallback(k[2], k[1]);
+            n[2].push(k[1], handler);
           }
         }
 

--- a/src/window/lifecycle.js
+++ b/src/window/lifecycle.js
@@ -49,8 +49,14 @@ export function render(fritz, msg){
 
 export function trigger(fritz, msg) {
   let inst = getInstance(fritz, msg.id);
-  let event = new Event(msg.event.type, {
-    bubbles: true
+  let ev = msg.event;
+  let event = new CustomEvent(ev.type, {
+    bubbles: true,//ev.bubbles,
+    cancelable: ev.cancelable,
+    detail: ev.detail,
+    scoped: ev.scoped,
+    composed: ev.composed
   });
+
   inst.dispatchEvent(event);  
 };

--- a/src/worker/component.js
+++ b/src/worker/component.js
@@ -11,6 +11,7 @@ class Component {
     });
   }
 
+  // Force an update, will change to setState()
   update() {
     let id = this._fritzId;
     postMessage({
@@ -19,6 +20,8 @@ class Component {
       tree: renderInstance(this)
     });
   }
+
+  componentWillUpdate(){}
 
   destroy(){}
 }

--- a/src/worker/hyperscript.js
+++ b/src/worker/hyperscript.js
@@ -1,3 +1,4 @@
+import { isFunction } from '../util.js';
 import signal from './signal.js';
 
 class Tree extends Array {}
@@ -14,7 +15,7 @@ export default function h(tag, attrs, children){
     children = Array.prototype.slice.call(arguments, 2);
   }
 
-  var isFn = typeof tag === 'function';
+  var isFn = isFunction(tag);
 
   if(isFn) {
     var localName = tag.prototype.localName;

--- a/src/worker/lifecycle.js
+++ b/src/worker/lifecycle.js
@@ -27,7 +27,11 @@ export function render(fritz, msg) {
     events = constructor.observedEvents;
   }
 
+  // TODO this should go into instance.props in the future.
   Object.assign(instance, props);
+
+  // TODO check for a shouldComponentUpdate
+  instance.componentWillUpdate();
 
   let tree = renderInstance(instance);
   postMessage({

--- a/test/events.html
+++ b/test/events.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title>Basic tests</title>
+  <title>Event tests</title>
   <link rel="import" href="../node_modules/mocha-test/mocha-test.html">
   <style>
     iframe { display: none; }
@@ -33,6 +33,10 @@
 
             let spec = shadow.querySelector('#foo');
             assert.equal(spec.textContent, 'bar', 'This element was updated');
+
+            // Custom events from child components to parents
+            let thing = shadow.querySelector('#thing');
+            assert.equal(thing.textContent, 'hello', 'This element updated');
           });
         });
 

--- a/test/events/app.js
+++ b/test/events/app.js
@@ -16,6 +16,10 @@ class EventEl extends Component {
     this.foo = ev.detail.foo;
   }
 
+  handleThing(ev) {
+    this.thing = ev.detail;
+  }
+
   render() {
     if(this.clicked) {
       return h('div', {'class': 'clicked'}, ['link clicked']);
@@ -28,12 +32,37 @@ class EventEl extends Component {
       }, ['Click me']),
 
       h('div', {id: 'foo'}, [this.foo]),
-      h('special-el', {onSpecial: this.handleSpecial}, [])
+      h('div', {id: 'thing'}, [this.thing]),
+      h('special-el', {onSpecial: this.handleSpecial}, []),
+      h('child-el', {onThing: this.handleThing}, [])
     ]);
   }
 }
 
 fritz.define('event-element', EventEl);
+
+class ChildEl extends Component {
+  constructor() {
+    super();
+    this.hasDispatched = false;
+  }
+
+  componentWillUpdate() {
+    if(!this.hasDispatched) {
+      // EWWWWW, how would you really do something like this?
+      setTimeout(_ => {
+        this.hasDispatched = true;
+        this.dispatch({ type: 'thing', detail: 'hello' });
+      });
+    }
+  }
+
+  render() {
+    return h('div', ['Child el']);
+  }
+}
+
+fritz.define('child-el', ChildEl);
 
 class InputEl extends Component {
   constructor() {

--- a/window.js
+++ b/window.js
@@ -1640,6 +1640,11 @@ function postEvent(event, inst, handle) {
 }
 
 const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
+  constructor() {
+    super();
+    this._handlers = Object.create(null);
+  }
+
   rendererCallback (shadowRoot, renderCallback) {
     this._worker.postMessage({
       type: RENDER,
@@ -1660,14 +1665,20 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
     });
   }
 
-  addEventCallback(handleId) {
+  addEventCallback(handleId, eventProp) {
+    var key = eventProp + '/' + handleId;
+    var fn;
+    if(fn = this._handlers[key]) {
+      return fn;
+    }
+
     // TODO optimize this so functions are reused if possible.
     var self = this;
-    var fn = function(ev){
+    fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
-
+    this._handlers[key] = fn;
     return fn;
   }
 

--- a/window.js
+++ b/window.js
@@ -1551,12 +1551,35 @@ var text_1 = text;
 var symbols_1 = symbols;
 var attributes_1 = attributes;
 
+function getInstance(fritz, id){
+  return fritz._instances[id];
+}
+
+function setInstance(fritz, id, instance){
+  fritz._instances[id] = instance;
+}
+
+function delInstance(fritz, id){
+  delete fritz._instances[id];
+}
+
+function isFunction(val) {
+  return typeof val === 'function';
+}
+
+var eventAttrExp = /^on[a-z]/;
+
 var attributesSet = attributes_1[symbols_1.default];
 attributes_1[symbols_1.default] = preferProps;
 
 function preferProps(element, name, value){
   if(name in element)
     element[name] = value;
+  else if(isFunction(value) && eventAttrExp.test(name) &&
+    isFunction(element.addEventProperty)) {
+    element.addEventProperty(name);
+    element[name] = value;
+  }
   else
     attributesSet(element, name, value);
 }
@@ -1569,9 +1592,11 @@ function render$1(bc, component){
       // Open
       case 1:
         if(n[3]) {
+          var k;
           for(var j = 0, jlen = n[3].length; j < jlen; j++) {
-            let handler = component.addEventCallback(n[3][j][2]);
-            n[2].push(n[3][j][1], handler);
+            k = n[3][j];
+            let handler = component.addEventCallback(k[2], k[1]);
+            n[2].push(k[1], handler);
           }
         }
 
@@ -1636,11 +1661,31 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
   }
 
   addEventCallback(handleId) {
+    // TODO optimize this so functions are reused if possible.
     var self = this;
-    return function(ev){
+    var fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
+
+    return fn;
+  }
+
+  addEventProperty(name) {
+    var evName = name.substr(2);
+    var priv = '_' + name;
+    var proto = Object.getPrototypeOf(this);
+    Object.defineProperty(proto, name, {
+      get: function(){ return this[priv]; },
+      set: function(val) {
+        var cur;
+        if(cur = this[priv]) {
+          this.removeEventListener(evName, cur);
+        }
+        this[priv] = val;
+        this.addEventListener(evName, val);
+      }
+    });
   }
 
   handleEvent(ev) {
@@ -1650,18 +1695,6 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
 };
 
 const Component = withComponent();
-
-function getInstance(fritz, id){
-  return fritz._instances[id];
-}
-
-function setInstance(fritz, id, instance){
-  fritz._instances[id] = instance;
-}
-
-function delInstance(fritz, id){
-  delete fritz._instances[id];
-}
 
 function define(fritz, msg) {
   let worker = this;
@@ -1710,9 +1743,15 @@ function render(fritz, msg){
 
 function trigger(fritz, msg) {
   let inst = getInstance(fritz, msg.id);
-  let event = new Event(msg.event.type, {
-    bubbles: true
+  let ev = msg.event;
+  let event = new CustomEvent(ev.type, {
+    bubbles: true,//ev.bubbles,
+    cancelable: ev.cancelable,
+    detail: ev.detail,
+    scoped: ev.scoped,
+    composed: ev.composed
   });
+
   inst.dispatchEvent(event);  
 }
 

--- a/window.umd.js
+++ b/window.umd.js
@@ -1557,12 +1557,35 @@ var text_1 = text;
 var symbols_1 = symbols;
 var attributes_1 = attributes;
 
+function getInstance(fritz, id){
+  return fritz._instances[id];
+}
+
+function setInstance(fritz, id, instance){
+  fritz._instances[id] = instance;
+}
+
+function delInstance(fritz, id){
+  delete fritz._instances[id];
+}
+
+function isFunction(val) {
+  return typeof val === 'function';
+}
+
+var eventAttrExp = /^on[a-z]/;
+
 var attributesSet = attributes_1[symbols_1.default];
 attributes_1[symbols_1.default] = preferProps;
 
 function preferProps(element, name, value){
   if(name in element)
     element[name] = value;
+  else if(isFunction(value) && eventAttrExp.test(name) &&
+    isFunction(element.addEventProperty)) {
+    element.addEventProperty(name);
+    element[name] = value;
+  }
   else
     attributesSet(element, name, value);
 }
@@ -1575,9 +1598,11 @@ function render$1(bc, component){
       // Open
       case 1:
         if(n[3]) {
+          var k;
           for(var j = 0, jlen = n[3].length; j < jlen; j++) {
-            let handler = component.addEventCallback(n[3][j][2]);
-            n[2].push(n[3][j][1], handler);
+            k = n[3][j];
+            let handler = component.addEventCallback(k[2], k[1]);
+            n[2].push(k[1], handler);
           }
         }
 
@@ -1642,11 +1667,31 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
   }
 
   addEventCallback(handleId) {
+    // TODO optimize this so functions are reused if possible.
     var self = this;
-    return function(ev){
+    var fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
+
+    return fn;
+  }
+
+  addEventProperty(name) {
+    var evName = name.substr(2);
+    var priv = '_' + name;
+    var proto = Object.getPrototypeOf(this);
+    Object.defineProperty(proto, name, {
+      get: function(){ return this[priv]; },
+      set: function(val) {
+        var cur;
+        if(cur = this[priv]) {
+          this.removeEventListener(evName, cur);
+        }
+        this[priv] = val;
+        this.addEventListener(evName, val);
+      }
+    });
   }
 
   handleEvent(ev) {
@@ -1656,18 +1701,6 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
 };
 
 const Component = withComponent();
-
-function getInstance(fritz, id){
-  return fritz._instances[id];
-}
-
-function setInstance(fritz, id, instance){
-  fritz._instances[id] = instance;
-}
-
-function delInstance(fritz, id){
-  delete fritz._instances[id];
-}
 
 function define(fritz, msg) {
   let worker = this;
@@ -1716,9 +1749,15 @@ function render(fritz, msg){
 
 function trigger(fritz, msg) {
   let inst = getInstance(fritz, msg.id);
-  let event = new Event(msg.event.type, {
-    bubbles: true
+  let ev = msg.event;
+  let event = new CustomEvent(ev.type, {
+    bubbles: true,//ev.bubbles,
+    cancelable: ev.cancelable,
+    detail: ev.detail,
+    scoped: ev.scoped,
+    composed: ev.composed
   });
+
   inst.dispatchEvent(event);  
 }
 

--- a/window.umd.js
+++ b/window.umd.js
@@ -1646,6 +1646,11 @@ function postEvent(event, inst, handle) {
 }
 
 const withComponent = (Base = HTMLElement) => class extends withUnique(withRender(withProps(Base))) {
+  constructor() {
+    super();
+    this._handlers = Object.create(null);
+  }
+
   rendererCallback (shadowRoot, renderCallback) {
     this._worker.postMessage({
       type: RENDER,
@@ -1666,14 +1671,20 @@ const withComponent = (Base = HTMLElement) => class extends withUnique(withRende
     });
   }
 
-  addEventCallback(handleId) {
+  addEventCallback(handleId, eventProp) {
+    var key = eventProp + '/' + handleId;
+    var fn;
+    if(fn = this._handlers[key]) {
+      return fn;
+    }
+
     // TODO optimize this so functions are reused if possible.
     var self = this;
-    var fn = function(ev){
+    fn = function(ev){
       ev.preventDefault();
       postEvent(ev, self, handleId);
     };
-
+    this._handlers[key] = fn;
     return fn;
   }
 

--- a/worker.js
+++ b/worker.js
@@ -24,6 +24,7 @@ class Component {
     });
   }
 
+  // Force an update, will change to setState()
   update() {
     let id = this._fritzId;
     postMessage({
@@ -33,7 +34,25 @@ class Component {
     });
   }
 
+  componentWillUpdate(){}
+
   destroy(){}
+}
+
+function getInstance(fritz, id){
+  return fritz._instances[id];
+}
+
+function setInstance(fritz, id, instance){
+  fritz._instances[id] = instance;
+}
+
+function delInstance(fritz, id){
+  delete fritz._instances[id];
+}
+
+function isFunction(val) {
+  return typeof val === 'function';
 }
 
 let Store;
@@ -120,7 +139,7 @@ function h(tag, attrs, children){
     children = Array.prototype.slice.call(arguments, 2);
   }
 
-  var isFn = typeof tag === 'function';
+  var isFn = isFunction(tag);
 
   if(isFn) {
     var localName = tag.prototype.localName;
@@ -177,18 +196,6 @@ function h(tag, attrs, children){
   return tree;
 }
 
-function getInstance(fritz, id){
-  return fritz._instances[id];
-}
-
-function setInstance(fritz, id, instance){
-  fritz._instances[id] = instance;
-}
-
-function delInstance(fritz, id){
-  delete fritz._instances[id];
-}
-
 function render(fritz, msg) {
   let id = msg.id;
   let props = msg.props || {};
@@ -213,7 +220,11 @@ function render(fritz, msg) {
     events = constructor.observedEvents;
   }
 
+  // TODO this should go into instance.props in the future.
   Object.assign(instance, props);
+
+  // TODO check for a shouldComponentUpdate
+  instance.componentWillUpdate();
 
   let tree = renderInstance(instance);
   postMessage({

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -30,6 +30,7 @@ class Component {
     });
   }
 
+  // Force an update, will change to setState()
   update() {
     let id = this._fritzId;
     postMessage({
@@ -39,7 +40,25 @@ class Component {
     });
   }
 
+  componentWillUpdate(){}
+
   destroy(){}
+}
+
+function getInstance(fritz, id){
+  return fritz._instances[id];
+}
+
+function setInstance(fritz, id, instance){
+  fritz._instances[id] = instance;
+}
+
+function delInstance(fritz, id){
+  delete fritz._instances[id];
+}
+
+function isFunction(val) {
+  return typeof val === 'function';
 }
 
 let Store;
@@ -126,7 +145,7 @@ function h(tag, attrs, children){
     children = Array.prototype.slice.call(arguments, 2);
   }
 
-  var isFn = typeof tag === 'function';
+  var isFn = isFunction(tag);
 
   if(isFn) {
     var localName = tag.prototype.localName;
@@ -183,18 +202,6 @@ function h(tag, attrs, children){
   return tree;
 }
 
-function getInstance(fritz, id){
-  return fritz._instances[id];
-}
-
-function setInstance(fritz, id, instance){
-  fritz._instances[id] = instance;
-}
-
-function delInstance(fritz, id){
-  delete fritz._instances[id];
-}
-
 function render(fritz, msg) {
   let id = msg.id;
   let props = msg.props || {};
@@ -219,7 +226,11 @@ function render(fritz, msg) {
     events = constructor.observedEvents;
   }
 
+  // TODO this should go into instance.props in the future.
   Object.assign(instance, props);
+
+  // TODO check for a shouldComponentUpdate
+  instance.componentWillUpdate();
 
   let tree = renderInstance(instance);
   postMessage({


### PR DESCRIPTION
This makes it possible for an element to dispatch custom events, and for
parent elements to be able to listen to custom events on children.
Passing `detail` works as well.

Closes #13