### PR TITLE
Implement React-like props, state, and lifecycle methods

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -13,3 +13,5 @@ export function delInstance(fritz, id){
 export function isFunction(val) {
   return typeof val === 'function';
 };
+
+export const defer = Promise.resolve().then.bind(Promise.resolve());

--- a/src/window/component.js
+++ b/src/window/component.js
@@ -40,12 +40,6 @@ export const withComponent = (Base = HTMLElement) => class extends withUnique(wi
     render(vdom, shadowRoot, this);
   }
 
-  observedEventsCallback(events) {
-    events.forEach(eventName => {
-      this.shadowRoot.addEventListener(eventName, this);
-    });
-  }
-
   addEventCallback(handleId, eventProp) {
     var key = eventProp + '/' + handleId;
     var fn;

--- a/src/window/lifecycle.js
+++ b/src/window/lifecycle.js
@@ -6,6 +6,7 @@ export function define(fritz, msg) {
   let worker = this;
   let tagName = msg.tag;
   let props = msg.props || {};
+  let events = msg.events || [];
 
   class OffThreadElement extends Component {
     static get props() {
@@ -21,11 +22,17 @@ export function define(fritz, msg) {
     connectedCallback() {
       super.connectedCallback();
       setInstance(fritz, this._id, this);
+      events.forEach(eventName => {
+        this.shadowRoot.addEventListener(eventName, this);
+      });
     }
 
     disconnectedCallback() {
       super.disconnectedCallback();
       delInstance(fritz, this._id);
+      events.forEach(eventName => {
+        this.shadowRoot.removeEventListener(eventName, this);
+      });
       this._worker.postMessage({
         type: DESTROY,
         id: this._id
@@ -41,9 +48,6 @@ export function render(fritz, msg){
   let instance = getInstance(fritz, msg.id);
   if(instance !== undefined) {
     instance.doRenderCallback(msg.tree);
-    if(msg.events) {
-      instance.observedEventsCallback(msg.events);
-    }
   }
 };
 

--- a/src/worker/component.js
+++ b/src/worker/component.js
@@ -1,7 +1,13 @@
+import { isFunction } from '../util.js';
 import { RENDER, TRIGGER } from '../message-types.js';
-import { renderInstance } from './instance.js';
+import { enqueueRender } from './instance.js';
 
 class Component {
+  constructor() {
+    this.state = {};
+    this.props = {};
+  }
+
   dispatch(ev) {
     let id = this._fritzId;
     postMessage({
@@ -11,19 +17,25 @@ class Component {
     });
   }
 
+  setState(state) {
+    let s = this.state;
+    Object.assign(s, isFunction(state) ? state(s, this.props) : state);
+    enqueueRender(this);
+  }
+
   // Force an update, will change to setState()
   update() {
-    let id = this._fritzId;
-    postMessage({
-      type: RENDER,
-      id: id,
-      tree: renderInstance(this)
-    });
+    console.warn('update() is deprecated. Use setState() instead.');
+    this.setState({});
+  }
+
+  shouldComponentUpdate() {
+    return true;
   }
 
   componentWillUpdate(){}
 
-  destroy(){}
+  componentWillUnmount(){}
 }
 
 export default Component;

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -32,7 +32,8 @@ function define(tag, constructor) {
   postMessage({
     type: DEFINE,
     tag: tag,
-    props: constructor.props
+    props: constructor.props,
+    events: constructor.events
   });
 }
 

--- a/src/worker/instance.js
+++ b/src/worker/instance.js
@@ -1,8 +1,25 @@
+import { RENDER } from '../message-types.js';
+
 export let currentInstance = null;
 
 export function renderInstance(instance) {
   currentInstance = instance;
-  let tree = instance.render(instance);
+  let tree = instance.render(instance.props, instance.state);
   currentInstance = null;
   return tree;
 };
+
+export function enqueueRender(instance, extra) {
+  if(instance.shouldComponentUpdate() !== false) {
+    instance.componentWillUpdate();
+
+    let id = instance._fritzId;
+    let msg = Object.assign({
+      type: RENDER,
+      id: id,
+      tree: renderInstance(instance)
+    }, extra);
+
+    postMessage(msg);
+  }  
+}

--- a/src/worker/lifecycle.js
+++ b/src/worker/lifecycle.js
@@ -23,12 +23,11 @@ export function render(fritz, msg) {
       }
     });
     setInstance(fritz, id, instance);
-    events = constructor.observedEvents;
   }
 
   Object.assign(instance.props, props);
 
-  enqueueRender(instance, { events: events });
+  enqueueRender(instance);
 };
 
 export function trigger(fritz, msg){
@@ -47,7 +46,7 @@ export function trigger(fritz, msg){
     let event = msg.event;
     method.call(inst, event);
 
-    enqueueRender(inst, { event: event });
+    enqueueRender(inst);
   } else {
     // TODO warn?
   }

--- a/src/worker/lifecycle.js
+++ b/src/worker/lifecycle.js
@@ -1,7 +1,6 @@
 import { getInstance, setInstance, delInstance } from '../util.js';
 import Handle from './handle.js';
-import { RENDER } from '../message-types.js';
-import { renderInstance } from './instance.js';
+import { enqueueRender } from './instance.js';
 
 export function render(fritz, msg) {
   let id = msg.id;
@@ -27,19 +26,9 @@ export function render(fritz, msg) {
     events = constructor.observedEvents;
   }
 
-  // TODO this should go into instance.props in the future.
-  Object.assign(instance, props);
+  Object.assign(instance.props, props);
 
-  // TODO check for a shouldComponentUpdate
-  instance.componentWillUpdate();
-
-  let tree = renderInstance(instance);
-  postMessage({
-    type: RENDER,
-    id: id,
-    tree: tree,
-    events: events
-  });
+  enqueueRender(instance, { events: events });
 };
 
 export function trigger(fritz, msg){
@@ -57,11 +46,8 @@ export function trigger(fritz, msg){
   if(method) {
     let event = msg.event;
     method.call(inst, event);
-    response.type = RENDER;
-    response.id = msg.id;
-    response.tree = renderInstance(inst);
-    response.event = event;
-    postMessage(response);
+
+    enqueueRender(inst, { event: event });
   } else {
     // TODO warn?
   }
@@ -69,7 +55,7 @@ export function trigger(fritz, msg){
 
 export function destroy(fritz, msg){
   let instance = getInstance(fritz, msg.id);
-  instance.destroy();
+  instance.componentWillUnmount();
   Object.keys(instance._fritzHandles).forEach(function(key){
     let handle = instance._fritzHandles[key];
     handle.del();

--- a/test/events/app.js
+++ b/test/events/app.js
@@ -5,23 +5,23 @@ const { h, Component } = fritz;
 class EventEl extends Component {
   constructor() {
     super();
-    this.foo = 'none';
+    this.state = { foo: 'none' };
   }
 
   myHandler() {
-    this.clicked = true;
+    this.setState({clicked: true});
   }
 
   handleSpecial(ev) {
-    this.foo = ev.detail.foo;
+    this.setState({foo: ev.detail.foo});
   }
 
   handleThing(ev) {
-    this.thing = ev.detail;
+    this.setState({thing: ev.detail});
   }
 
-  render() {
-    if(this.clicked) {
+  render({}, {clicked, foo, thing}) {
+    if(clicked) {
       return h('div', {'class': 'clicked'}, ['link clicked']);
     }
 
@@ -31,8 +31,8 @@ class EventEl extends Component {
         onClick: this.myHandler
       }, ['Click me']),
 
-      h('div', {id: 'foo'}, [this.foo]),
-      h('div', {id: 'thing'}, [this.thing]),
+      h('div', {id: 'foo'}, [foo]),
+      h('div', {id: 'thing'}, [thing]),
       h('special-el', {onSpecial: this.handleSpecial}, []),
       h('child-el', {onThing: this.handleThing}, [])
     ]);

--- a/test/props/app.js
+++ b/test/props/app.js
@@ -11,8 +11,8 @@ class Hello extends Component {
     };
   }
 
-  render() {
-    return h('span', [`Hello ${this.name}`]);
+  render({name}) {
+    return h('span', [`Hello ${name}`]);
   }
 }
 

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -4,47 +4,6 @@
 	(global.fritz = factory());
 }(this, (function () { 'use strict';
 
-const DEFINE = 'define';
-const TRIGGER = 'trigger';
-const RENDER = 'render';
-const EVENT = 'event';
-const STATE = 'state';
-const DESTROY = 'destroy';
-
-let currentInstance = null;
-
-function renderInstance(instance) {
-  currentInstance = instance;
-  let tree = instance.render(instance);
-  currentInstance = null;
-  return tree;
-}
-
-class Component {
-  dispatch(ev) {
-    let id = this._fritzId;
-    postMessage({
-      type: TRIGGER,
-      event: ev,
-      id: id
-    });
-  }
-
-  // Force an update, will change to setState()
-  update() {
-    let id = this._fritzId;
-    postMessage({
-      type: RENDER,
-      id: id,
-      tree: renderInstance(this)
-    });
-  }
-
-  componentWillUpdate(){}
-
-  destroy(){}
-}
-
 function getInstance(fritz, id){
   return fritz._instances[id];
 }
@@ -59,6 +18,73 @@ function delInstance(fritz, id){
 
 function isFunction(val) {
   return typeof val === 'function';
+}
+
+const DEFINE = 'define';
+const TRIGGER = 'trigger';
+const RENDER = 'render';
+const EVENT = 'event';
+const STATE = 'state';
+const DESTROY = 'destroy';
+
+let currentInstance = null;
+
+function renderInstance(instance) {
+  currentInstance = instance;
+  let tree = instance.render(instance.props, instance.state);
+  currentInstance = null;
+  return tree;
+}
+
+function enqueueRender(instance, extra) {
+  if(instance.shouldComponentUpdate() !== false) {
+    instance.componentWillUpdate();
+
+    let id = instance._fritzId;
+    let msg = Object.assign({
+      type: RENDER,
+      id: id,
+      tree: renderInstance(instance)
+    }, extra);
+
+    postMessage(msg);
+  }  
+}
+
+class Component {
+  constructor() {
+    this.state = {};
+    this.props = {};
+  }
+
+  dispatch(ev) {
+    let id = this._fritzId;
+    postMessage({
+      type: TRIGGER,
+      event: ev,
+      id: id
+    });
+  }
+
+  setState(state) {
+    let s = this.state;
+    Object.assign(s, isFunction(state) ? state(s, this.props) : state);
+    enqueueRender(this);
+  }
+
+  // Force an update, will change to setState()
+  update() {
+    console.warn('update() is deprecated. Use setState() instead.');
+    this.setState({});
+  }
+
+  shouldComponentUpdate() {
+    return true;
+  }
+
+  componentWillUpdate(){}
+
+  componentWillUnmount(){}
 }
 
 let Store;
@@ -226,19 +252,9 @@ function render(fritz, msg) {
     events = constructor.observedEvents;
   }
 
-  // TODO this should go into instance.props in the future.
-  Object.assign(instance, props);
+  Object.assign(instance.props, props);
 
-  // TODO check for a shouldComponentUpdate
-  instance.componentWillUpdate();
-
-  let tree = renderInstance(instance);
-  postMessage({
-    type: RENDER,
-    id: id,
-    tree: tree,
-    events: events
-  });
+  enqueueRender(instance, { events: events });
 }
 
 function trigger(fritz, msg){
@@ -256,11 +272,8 @@ function trigger(fritz, msg){
   if(method) {
     let event = msg.event;
     method.call(inst, event);
-    response.type = RENDER;
-    response.id = msg.id;
-    response.tree = renderInstance(inst);
-    response.event = event;
-    postMessage(response);
+
+    enqueueRender(inst, { event: event });
   } else {
     // TODO warn?
   }
@@ -268,7 +281,7 @@ function trigger(fritz, msg){
 
 function destroy(fritz, msg){
   let instance = getInstance(fritz, msg.id);
-  instance.destroy();
+  instance.componentWillUnmount();
   Object.keys(instance._fritzHandles).forEach(function(key){
     let handle = instance._fritzHandles[key];
     handle.del();

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -20,6 +20,8 @@ function isFunction(val) {
   return typeof val === 'function';
 }
 
+const defer = Promise.resolve().then.bind(Promise.resolve());
+
 const DEFINE = 'define';
 const TRIGGER = 'trigger';
 const RENDER = 'render';
@@ -36,19 +38,33 @@ function renderInstance(instance) {
   return tree;
 }
 
-function enqueueRender(instance, extra) {
+let queue = [];
+
+function enqueueRender(instance) {
+  if(!instance._dirty && (instance._dirty = true) && queue.push(instance)==1) {
+    defer(rerender);
+  }
+}
+
+function rerender() {
+	let p, list = queue;
+	queue = [];
+	while ( (p = list.pop()) ) {
+		if (p._dirty) render(p);
+	}
+}
+
+function render(instance) {
   if(instance.shouldComponentUpdate() !== false) {
     instance.componentWillUpdate();
+    instance._dirty = false;
 
-    let id = instance._fritzId;
-    let msg = Object.assign({
+    postMessage({
       type: RENDER,
-      id: id,
+      id: instance._fritzId,
       tree: renderInstance(instance)
-    }, extra);
-
-    postMessage(msg);
-  }  
+    });
+  }
 }
 
 class Component {
@@ -228,7 +244,7 @@ function h(tag, attrs, children){
   return tree;
 }
 
-function render(fritz, msg) {
+function render$1(fritz, msg) {
   let id = msg.id;
   let props = msg.props || {};
 
@@ -249,12 +265,11 @@ function render(fritz, msg) {
       }
     });
     setInstance(fritz, id, instance);
-    events = constructor.observedEvents;
   }
 
   Object.assign(instance.props, props);
 
-  enqueueRender(instance, { events: events });
+  enqueueRender(instance);
 }
 
 function trigger(fritz, msg){
@@ -273,7 +288,7 @@ function trigger(fritz, msg){
     let event = msg.event;
     method.call(inst, event);
 
-    enqueueRender(inst, { event: event });
+    enqueueRender(inst);
   } else {
     // TODO warn?
   }
@@ -300,7 +315,7 @@ function relay(fritz) {
       let msg = ev.data;
       switch(msg.type) {
         case RENDER:
-          render(fritz, msg);
+          render$1(fritz, msg);
           break;
         case EVENT:
           trigger(fritz, msg);
@@ -345,7 +360,8 @@ function define(tag, constructor) {
   postMessage({
     type: DEFINE,
     tag: tag,
-    props: constructor.props
+    props: constructor.props,
+    events: constructor.events
   });
 }
 


### PR DESCRIPTION
This steals the lifecycle methods and props, state being passed into the
`render()` method. Breaking change. Closes #14