### PR TITLE
hyperscript: allow children that are numbers or booleans

### DIFF
--- a/src/worker/hyperscript.js
+++ b/src/worker/hyperscript.js
@@ -3,14 +3,14 @@ import signal from './signal.js';
 import { createTree, isTree } from './tree.js';
 
 export default function h(tag, attrs, children){
-  const argsLen = arguments.length;
+  var argsLen = arguments.length;
+  var childrenType = typeof children;
   if(argsLen === 2) {
     if(typeof attrs !== 'object' || Array.isArray(attrs)) {
       children = attrs;
       attrs = null;
     }
-  } else if(argsLen > 3 || isTree(children) ||
-    typeof children === 'string') {
+  } else if(argsLen > 3 || isTree(children) || isPrimitive(childrenType)) {
     children = Array.prototype.slice.call(arguments, 2);
   }
 
@@ -73,3 +73,7 @@ export default function h(tag, attrs, children){
 
   return tree;
 };
+
+function isPrimitive(type) {
+  return type === 'string' || type === 'number' || type === 'boolean';
+}

--- a/test/basics.html
+++ b/test/basics.html
@@ -48,7 +48,21 @@
             let loading = el.shadowRoot.querySelector('loading-indicator');
             let svg = loading.shadowRoot.firstChild;
             assert.ok(svg.hasAttribute('viewBox'), 'has the viewBox');
-          })
+          });
+
+          it('renders children that are numbers', function(){
+            let root = doc.querySelector('basic-app').shadowRoot;
+            let el = root.querySelector('typed-el').shadowRoot;
+            let val = el.querySelector('.c-number').firstChild.nodeValue;
+            assert.equal(val, '27', 'printed the string 27');
+          });
+
+          it('renders children that are booleans', function(){
+            let root = doc.querySelector('basic-app').shadowRoot;
+            let el = root.querySelector('typed-el').shadowRoot;
+            let val = el.querySelector('.c-boolean').firstChild.nodeValue;
+            assert.equal(val, 'false', 'printed the string false');
+          });
         });
       </script>
     </template>

--- a/test/basics/app.js
+++ b/test/basics/app.js
@@ -28,12 +28,24 @@ class MathEl extends Component {
 
 fritz.define('math-el', MathEl);
 
+class TypedEl extends Component {
+  render() {
+    return h('div', {}, [
+      h('div', {'class':'c-number'}, 27),
+      h('div', {'class':'c-boolean'}, false),
+    ]);
+  }
+}
+
+fritz.define('typed-el', TypedEl);
+
 class BasicApp extends Component {
   render() {
     return h('div', {id:'root'}, [
       'Hello world!',
       h(AnotherEl),
       h(MathEl),
+      h(TypedEl),
       h('loading-indicator')
     ]);
   }

--- a/worker.js
+++ b/worker.js
@@ -188,14 +188,14 @@ function createTree() {
 }
 
 function h(tag, attrs, children){
-  const argsLen = arguments.length;
+  var argsLen = arguments.length;
+  var childrenType = typeof children;
   if(argsLen === 2) {
     if(typeof attrs !== 'object' || Array.isArray(attrs)) {
       children = attrs;
       attrs = null;
     }
-  } else if(argsLen > 3 || isTree(children) ||
-    typeof children === 'string') {
+  } else if(argsLen > 3 || isTree(children) || isPrimitive(childrenType)) {
     children = Array.prototype.slice.call(arguments, 2);
   }
 
@@ -257,6 +257,10 @@ function h(tag, attrs, children){
   tree.push([2, tag]);
 
   return tree;
+}
+
+function isPrimitive(type) {
+  return type === 'string' || type === 'number' || type === 'boolean';
 }
 
 function render$1(fritz, msg) {

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -194,14 +194,14 @@ function createTree() {
 }
 
 function h(tag, attrs, children){
-  const argsLen = arguments.length;
+  var argsLen = arguments.length;
+  var childrenType = typeof children;
   if(argsLen === 2) {
     if(typeof attrs !== 'object' || Array.isArray(attrs)) {
       children = attrs;
       attrs = null;
     }
-  } else if(argsLen > 3 || isTree(children) ||
-    typeof children === 'string') {
+  } else if(argsLen > 3 || isTree(children) || isPrimitive(childrenType)) {
     children = Array.prototype.slice.call(arguments, 2);
   }
 
@@ -263,6 +263,10 @@ function h(tag, attrs, children){
   tree.push([2, tag]);
 
   return tree;
+}
+
+function isPrimitive(type) {
+  return type === 'string' || type === 'number' || type === 'boolean';
 }
 
 function render$1(fritz, msg) {


### PR DESCRIPTION
This makes it so the following work:

```js
h('div', {}, 27),
h('div', {}, false)
```