### PR TITLE
Adds a garbage collector for handles

### DIFF
--- a/src/worker/collect.js
+++ b/src/worker/collect.js
@@ -1,0 +1,31 @@
+
+let queue = new Set();
+let markId = null;
+
+function collect(instance) {
+  queue.add(instance);
+  if(markId === null) {
+    markId = setTimeout(runCollection, 40);
+  }
+}
+
+function runCollection() {
+  queue.forEach(function(instance) {
+    let handles = instance._fritzHandles;
+    handles.forEach(function(handle){
+      // Mark
+      if(handle.inUse) {
+        handle.inUse = false;
+      }
+      // Sweep
+      else {
+        handle.del();
+        handles.delete(handle.id);
+      }
+    });
+    queue.delete(instance);
+  });
+  markId = null;
+}
+
+export { collect };

--- a/src/worker/collect.js
+++ b/src/worker/collect.js
@@ -23,8 +23,8 @@ function runCollection() {
         handles.delete(handle.id);
       }
     });
-    queue.delete(instance);
   });
+  queue.clear();
   markId = null;
 }
 

--- a/src/worker/handle.js
+++ b/src/worker/handle.js
@@ -5,6 +5,7 @@ Store = class {
     this.handleMap = new WeakMap();
     this.idMap = new Map();
     this.id = 0;
+    this.inUse = true;
   }
 
   from(fn) {

--- a/src/worker/instance.js
+++ b/src/worker/instance.js
@@ -1,4 +1,5 @@
 import { RENDER } from '../message-types.js';
+import { collect } from './collect.js';
 import { defer } from '../util.js';
 
 export let currentInstance = null;
@@ -42,5 +43,7 @@ function render(instance, sentProps) {
       id: instance._fritzId,
       tree: renderInstance(instance)
     });
+    
+    collect(instance);
   }
 }

--- a/src/worker/lifecycle.js
+++ b/src/worker/lifecycle.js
@@ -18,7 +18,7 @@ export function render(fritz, msg) {
       _fritzHandles: {
         enumerable: false,
         writable: true,
-        value: Object.create(null)
+        value: new Map()
       }
     });
     setInstance(fritz, id, instance);

--- a/src/worker/signal.js
+++ b/src/worker/signal.js
@@ -7,7 +7,8 @@ function signal(tagName, attrName, attrValue, attrs) {
   if(eventAttrExp.test(attrName)) {
     let eventName = attrName.toLowerCase();
     let handle = Handle.from(attrValue);
-    currentInstance._fritzHandles[handle.id] = handle;
+    handle.inUse = true;
+    currentInstance._fritzHandles.set(handle.id, handle);
     return [1, eventName, handle.id];
   }
 }

--- a/test/garbage.html
+++ b/test/garbage.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <title>GC tests</title>
+  <link rel="import" href="../node_modules/mocha-test/mocha-test.html">
+  <style>
+    iframe { display: none; }
+  </style>
+</head>
+<body>
+  <iframe id="gcFrame" src="./garbage/index.html"></iframe>
+  <mocha-test>
+    <template>
+      <script>
+        describe('Garbage Collection', function(){
+          const win = gcFrame.contentWindow;
+          const doc = gcFrame.contentDocument;
+
+          before(function(done) {
+            setTimeout(done, 100);
+          });
+
+          it('Triggering a render gives 2 handles', function(done){
+            let shadow = doc.querySelector('gc-app').shadowRoot;
+            let btn = shadow.querySelector('#increment');
+            let sizeSpan = shadow.querySelector('#handleSize');
+
+            btn.dispatchEvent(new Event('click'));
+
+            setTimeout(function(){
+              assert.equal(sizeSpan.textContent, '2');
+
+              // Now trigger another.
+              btn.dispatchEvent(new Event('click'));
+              setTimeout(function(){
+                assert.equal(sizeSpan.textContent, '2', 'still is 2');
+
+                done();
+              }, 60);
+            }, 60);
+          })
+        });
+      </script>
+    </template>
+  </mocha-test>
+</body>
+</html>

--- a/test/garbage/app.js
+++ b/test/garbage/app.js
@@ -1,0 +1,38 @@
+importScripts('../../worker.umd.js');
+importScripts('../worker-debug.js');
+
+const { h, Component } = fritz;
+
+class App extends Component {
+  constructor() {
+    super();
+    this.state = { count: 0 };
+  }
+
+  decrement() {
+    let {count} = this.state;
+    this.setState({count: count - 1});
+  }
+
+  render({}, {count}) {
+    var size = this._fritzHandles.size;
+    return (
+      h('div', [
+        h('button', {
+          id: 'increment',
+          onClick: () => this.setState({count: count + 1})
+        }, 'Increment'),
+        h('button', {
+          onClick: this.decrement
+        }, 'Decrement'),
+        h('div', ['Count: ' + count]),
+        h('div', [
+          'Handles: ',
+          h('span', {id:'handleSize'}, [size])
+        ])
+      ])
+    );
+  }
+}
+
+fritz.define('gc-app', App);

--- a/test/garbage/index.html
+++ b/test/garbage/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<gc-app></gc-app>
+<script src="../../window.umd.js"></script>
+<script>
+  fritz.use(new Worker('./app.js'));
+</script>

--- a/worker.js
+++ b/worker.js
@@ -50,8 +50,8 @@ function runCollection() {
         handles.delete(handle.id);
       }
     });
-    queue$1.delete(instance);
   });
+  queue$1.clear();
   markId = null;
 }
 

--- a/worker.js
+++ b/worker.js
@@ -26,6 +26,35 @@ const STATE = 'state';
 const DESTROY = 'destroy';
 const RENDERED = 'rendered';
 
+let queue$1 = new Set();
+let markId = null;
+
+function collect(instance) {
+  queue$1.add(instance);
+  if(markId === null) {
+    markId = setTimeout(runCollection, 40);
+  }
+}
+
+function runCollection() {
+  queue$1.forEach(function(instance) {
+    let handles = instance._fritzHandles;
+    handles.forEach(function(handle){
+      // Mark
+      if(handle.inUse) {
+        handle.inUse = false;
+      }
+      // Sweep
+      else {
+        handle.del();
+        handles.delete(handle.id);
+      }
+    });
+    queue$1.delete(instance);
+  });
+  markId = null;
+}
+
 let currentInstance = null;
 
 function renderInstance(instance) {
@@ -67,6 +96,8 @@ function render(instance, sentProps) {
       id: instance._fritzId,
       tree: renderInstance(instance)
     });
+    
+    collect(instance);
   }
 }
 
@@ -113,6 +144,7 @@ Store = class {
     this.handleMap = new WeakMap();
     this.idMap = new Map();
     this.id = 0;
+    this.inUse = true;
   }
 
   from(fn) {
@@ -170,7 +202,8 @@ function signal(tagName, attrName, attrValue, attrs) {
   if(eventAttrExp.test(attrName)) {
     let eventName = attrName.toLowerCase();
     let handle = Handle$1.from(attrValue);
-    currentInstance._fritzHandles[handle.id] = handle;
+    handle.inUse = true;
+    currentInstance._fritzHandles.set(handle.id, handle);
     return [1, eventName, handle.id];
   }
 }
@@ -279,7 +312,7 @@ function render$1(fritz, msg) {
       _fritzHandles: {
         enumerable: false,
         writable: true,
-        value: Object.create(null)
+        value: new Map()
       }
     });
     setInstance(fritz, id, instance);

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -56,8 +56,8 @@ function runCollection() {
         handles.delete(handle.id);
       }
     });
-    queue$1.delete(instance);
   });
+  queue$1.clear();
   markId = null;
 }
 

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -32,6 +32,35 @@ const STATE = 'state';
 const DESTROY = 'destroy';
 const RENDERED = 'rendered';
 
+let queue$1 = new Set();
+let markId = null;
+
+function collect(instance) {
+  queue$1.add(instance);
+  if(markId === null) {
+    markId = setTimeout(runCollection, 40);
+  }
+}
+
+function runCollection() {
+  queue$1.forEach(function(instance) {
+    let handles = instance._fritzHandles;
+    handles.forEach(function(handle){
+      // Mark
+      if(handle.inUse) {
+        handle.inUse = false;
+      }
+      // Sweep
+      else {
+        handle.del();
+        handles.delete(handle.id);
+      }
+    });
+    queue$1.delete(instance);
+  });
+  markId = null;
+}
+
 let currentInstance = null;
 
 function renderInstance(instance) {
@@ -73,6 +102,8 @@ function render(instance, sentProps) {
       id: instance._fritzId,
       tree: renderInstance(instance)
     });
+    
+    collect(instance);
   }
 }
 
@@ -119,6 +150,7 @@ Store = class {
     this.handleMap = new WeakMap();
     this.idMap = new Map();
     this.id = 0;
+    this.inUse = true;
   }
 
   from(fn) {
@@ -176,7 +208,8 @@ function signal(tagName, attrName, attrValue, attrs) {
   if(eventAttrExp.test(attrName)) {
     let eventName = attrName.toLowerCase();
     let handle = Handle$1.from(attrValue);
-    currentInstance._fritzHandles[handle.id] = handle;
+    handle.inUse = true;
+    currentInstance._fritzHandles.set(handle.id, handle);
     return [1, eventName, handle.id];
   }
 }
@@ -285,7 +318,7 @@ function render$1(fritz, msg) {
       _fritzHandles: {
         enumerable: false,
         writable: true,
-        value: Object.create(null)
+        value: new Map()
       }
     });
     setInstance(fritz, id, instance);


### PR DESCRIPTION
Each time a render occurs we queue a GC event, which will go through all
of the handles for an instance and mark them as not in use. This is the
sweep phase. The next time a collection occurs items marked as not in
use are removed from the instance map and overall handle store.

Fixes #30