### PR TITLE
Add support for JSX Fragments

### DIFF
--- a/src/worker/hyperscript.js
+++ b/src/worker/hyperscript.js
@@ -2,6 +2,18 @@ import { isFunction } from '../util.js';
 import signal from './signal.js';
 import { createTree, isTree } from './tree.js';
 
+function Fragment(attrs, children) {
+  var child;
+  var tree = createTree();
+  for(var i = 0; i < children.length; i++) {
+    child = children[i];
+    tree.push.apply(tree, child);
+  }
+  return tree;
+}
+
+export { Fragment };
+
 export default function h(tag, attrs, children){
   var argsLen = arguments.length;
   var childrenType = typeof children;
@@ -73,6 +85,8 @@ export default function h(tag, attrs, children){
 
   return tree;
 };
+
+h.frag = Fragment;
 
 function isPrimitive(type) {
   return type === 'string' || type === 'number' || type === 'boolean';

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -1,5 +1,5 @@
 import Component from './component.js';
-import h from './hyperscript.js';
+import h, { Fragment } from './hyperscript.js';
 import relay from './relay.js';
 import { DEFINE } from '../message-types.js';
 
@@ -48,4 +48,4 @@ Object.defineProperty(fritz, 'state', {
 });
 
 export default fritz;
-export { Component, h, state };
+export { Component, h, Fragment, state };

--- a/test/basics.html
+++ b/test/basics.html
@@ -63,6 +63,15 @@
             let val = el.querySelector('.c-boolean').firstChild.nodeValue;
             assert.equal(val, 'false', 'printed the string false');
           });
+
+          it('renders fragments', function(){
+            let root = doc.querySelector('basic-app').shadowRoot;
+            let el = root.querySelector('frag-el').shadowRoot;
+
+            assert.ok(el.querySelector('#one'), 'an element');
+            assert.ok(el.querySelector('#two'), 'another el');
+            assert.ok(el.querySelector('#three'), 'a nested fragment');
+          });
         });
       </script>
     </template>

--- a/test/basics/app.js
+++ b/test/basics/app.js
@@ -39,6 +39,22 @@ class TypedEl extends Component {
 
 fritz.define('typed-el', TypedEl);
 
+fritz.define('frag-el', class extends Component {
+  render() {
+    return (
+      h(h.frag, null,
+        h("div", {id:'one'}, "One"),
+        h("div", {id:'two'}, "Two"),
+        h("div", null,
+          h(h.frag, null,
+            h("span", {id:'three'}, "Three")
+          )
+        )
+      )
+    );
+  }
+})
+
 class BasicApp extends Component {
   render() {
     return h('div', {id:'root'}, [
@@ -46,7 +62,8 @@ class BasicApp extends Component {
       h(AnotherEl),
       h(MathEl),
       h(TypedEl),
-      h('loading-indicator')
+      h('loading-indicator'),
+      h('frag-el')
     ]);
   }
 }

--- a/worker.js
+++ b/worker.js
@@ -190,6 +190,16 @@ function createTree() {
   return out;
 }
 
+function Fragment(attrs, children) {
+  var child;
+  var tree = createTree();
+  for(var i = 0; i < children.length; i++) {
+    child = children[i];
+    tree.push.apply(tree, child);
+  }
+  return tree;
+}
+
 function h(tag, attrs, children){
   var argsLen = arguments.length;
   var childrenType = typeof children;
@@ -261,6 +271,8 @@ function h(tag, attrs, children){
 
   return tree;
 }
+
+h.frag = Fragment;
 
 function isPrimitive(type) {
   return type === 'string' || type === 'number' || type === 'boolean';
@@ -418,4 +430,4 @@ Object.defineProperty(fritz, 'state', {
   get: function() { return state; }
 });
 
-export { Component, h, state };export default fritz;
+export { Component, h, Fragment, state };export default fritz;

--- a/worker.umd.js
+++ b/worker.umd.js
@@ -196,6 +196,16 @@ function createTree() {
   return out;
 }
 
+function Fragment(attrs, children) {
+  var child;
+  var tree = createTree();
+  for(var i = 0; i < children.length; i++) {
+    child = children[i];
+    tree.push.apply(tree, child);
+  }
+  return tree;
+}
+
 function h(tag, attrs, children){
   var argsLen = arguments.length;
   var childrenType = typeof children;
@@ -267,6 +277,8 @@ function h(tag, attrs, children){
 
   return tree;
 }
+
+h.frag = Fragment;
 
 function isPrimitive(type) {
   return type === 'string' || type === 'number' || type === 'boolean';


### PR DESCRIPTION
This adds support for JSX fragments. This API can be used one of two
ways. You can either config Babel to allow `<>` syntax in your
`.babelrc`:

```json
{
  "plugins": ["@babel/plugin-transform-react-jsx", {
    "pragma": "h",
    "pragmaFrag": "h.frag"
  }]
}
```

In which case you can use it like so:

```js
import fritz, { h, Component } from 'fritz';

class MyApp extends Component {
  render() {
    return <>
      <dt>One</dt>
      <dd>two</dd>
    </>
  }
}
```

*Or* you can use the `Fragment` export like so:

```js
import fritz, { h, Fragment, Component } from 'fritz';

class MyApp extends Component {
  render() {
    return <Fragment>
      <dt>One</dt>
      <dd>two</dd>
    </Fragment>
  }
}
```

The former requires Babel 7, the latter can be used in Babel 6.