### PR TITLE
JSX fixes

### DIFF
--- a/.changeset/calm-pans-accept.md
+++ b/.changeset/calm-pans-accept.md
@@ -1,0 +1,5 @@
+---
+"fritz": patch
+---
+
+Improved JSX for custom elements

--- a/core/src/worker/component.ts
+++ b/core/src/worker/component.ts
@@ -35,7 +35,7 @@ abstract class Component<P, S> {
     });
   }
 
-  setState(state: S | ((state: S, props: P) => S)) {
+  setState<K extends keyof S>(state: Record<K, S[K]> | ((state: S, props: P) => S)) {
     let s = this.state;
     Object.assign(s as any, isFunction(state) ? state(s, this.props) : state);
     enqueueRender(this);

--- a/core/src/worker/jsx.d.ts
+++ b/core/src/worker/jsx.d.ts
@@ -671,6 +671,7 @@ export namespace JSXInternal {
 		crossOrigin?: string;
 		data?: string;
 		dateTime?: string;
+		datetime?: string;
 		default?: boolean;
 		defaultChecked?: boolean;
 		defaultValue?: string;
@@ -786,6 +787,7 @@ export namespace JSXInternal {
 		style?: string | CSSProperties;
 		summary?: string;
 		tabIndex?: number;
+		tabindex?: string;
 		target?: string;
 		title?: string;
 		type?: string;
@@ -852,7 +854,13 @@ export namespace JSXInternal {
 		width?: number | string;
 	}
 
-	export interface IntrinsicElements {
+	type CustomElementAttributes = HTMLAttributes<HTMLElement> & { [k: string]: unknown; };
+
+  export interface BaseIntrinsicElements {
+    [k: string]: CustomElementAttributes | HTMLAttributes<HTMLElement> | SVGAttributes<SVGElement>;
+  }
+
+	export interface IntrinsicElements extends BaseIntrinsicElements {
 		// HTML
 		a: HTMLAttributes<HTMLAnchorElement>;
 		abbr: HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
- Allow custom elements to work by default.
- HTML attributes vs props.
- Partial setState.